### PR TITLE
update userid from int64 to string

### DIFF
--- a/dong-service/handlers/offer_handlers.go
+++ b/dong-service/handlers/offer_handlers.go
@@ -46,7 +46,7 @@ func (h *OfferHandler) CreateOffer(c *gin.Context) {
 		return
 	}
 
-	userID, err := utils.GetUserIDFromContext(c)
+	userID, err := utils.GetUserIDStringFromContext(c)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, models.ErrorResponse(http.StatusUnauthorized, "authentication required"))
 		return

--- a/dong-service/handlers/order_handlers.go
+++ b/dong-service/handlers/order_handlers.go
@@ -50,7 +50,7 @@ func (h *OrderHandler) CreateOrder(c *gin.Context) {
 		return
 	}
 
-	userID, err := utils.GetUserIDFromContext(c)
+	userID, err := utils.GetUserIDStringFromContext(c)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, models.ErrorResponse(http.StatusUnauthorized, "authentication required"))
 		return

--- a/dong-service/migrations/018_add_seller_user_id_to_offers.sql
+++ b/dong-service/migrations/018_add_seller_user_id_to_offers.sql
@@ -1,8 +1,8 @@
 ALTER TABLE IF EXISTS dong_schema.offers
-ADD COLUMN IF NOT EXISTS seller_user_id BIGINT;
+ADD COLUMN IF NOT EXISTS seller_user_id TEXT;
 
 ALTER TABLE IF EXISTS dong_schema.orders
-ADD COLUMN IF NOT EXISTS buyer_user_id BIGINT;
+ADD COLUMN IF NOT EXISTS buyer_user_id TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_offers_seller_user_id ON dong_schema.offers (seller_user_id);
 CREATE INDEX IF NOT EXISTS idx_orders_buyer_user_id ON dong_schema.orders (buyer_user_id);

--- a/dong-service/models/offer.go
+++ b/dong-service/models/offer.go
@@ -16,7 +16,7 @@ const (
 
 type Offer struct {
 	OfferID                   int64       `json:"offer_id" db:"offer_id"`
-	SellerUserID              int64       `json:"seller_user_id" db:"seller_user_id"`
+	SellerUserID              string       `json:"seller_user_id" db:"seller_user_id"`
 	IntermediaryWalletAddress *string     `json:"intermediary_wallet_address,omitempty" db:"intermediary_wallet_address"`
 	SellerWalletAddress       string      `json:"seller_wallet_address" db:"seller_wallet_address"`
 	Side                      OfferSide   `json:"side" db:"side"` // BUY or SELL

--- a/dong-service/models/order.go
+++ b/dong-service/models/order.go
@@ -21,7 +21,7 @@ type Order struct {
 	OrderID             int64      `json:"order_id" db:"order_id"`
 	OfferID             *int64     `json:"offer_id,omitempty" db:"offer_id"`
 	BuyerWalletAddress  *string    `json:"buyer_wallet_address,omitempty" db:"buyer_wallet_address"`
-	BuyerUserID         int64      `json:"buyer_user_id" db:"buyer_user_id"`
+	BuyerUserID         string      `json:"buyer_user_id" db:"buyer_user_id"`
 	Amount              int64      `json:"amount" db:"amount"`
 	PayableAmount       int64      `json:"payable_amount" db:"payable_amount"`
 	TransactionHash     *string    `json:"transaction_hash,omitempty" db:"transaction_hash"`
@@ -32,7 +32,7 @@ type Order struct {
 	UpdatedAt           time.Time  `json:"updated_at" db:"updated_at"`
 	BankInfo            *string    `json:"bank_info,omitempty" db:"-"`
 	SellerWalletAddress *string    `json:"seller_wallet_address,omitempty" db:"-"`
-	SellerUserID        *int64     `json:"seller_user_id,omitempty" db:"-"`
+	SellerUserID        *string     `json:"seller_user_id,omitempty" db:"-"`
 	PriceRate           *float64   `json:"price_rate,omitempty" db:"-"`
 }
 

--- a/dong-service/services/offer_service.go
+++ b/dong-service/services/offer_service.go
@@ -29,7 +29,7 @@ func NewOfferService(repo *repository.OfferRepository, walletRepo *repository.In
 }
 
 type IOfferService interface {
-	CreateOffer(ctx context.Context, req *models.CreateOfferRequest, walletAddr string, sellerUserID int64) (*models.Offer, error)
+	CreateOffer(ctx context.Context, req *models.CreateOfferRequest, walletAddr string, sellerUserID string) (*models.Offer, error)
 	ListOffers(ctx context.Context, fromAmount *string, toAmount *string, pagination map[string]any) ([]models.Offer, error)
 	CountOffers(ctx context.Context, walletAddress *string, fromAmount *string, toAmount *string) (int64, error)
 	GetOfferByID(ctx context.Context, id int64) (*models.Offer, error)
@@ -37,7 +37,7 @@ type IOfferService interface {
 	UpdateOfferStatus(ctx context.Context, req *models.UpdateOfferStatusRequest) error
 }
 
-func (s *OfferService) CreateOffer(ctx context.Context, req *models.CreateOfferRequest, walletAddr string, sellerUserID int64) (*models.Offer, error) {
+func (s *OfferService) CreateOffer(ctx context.Context, req *models.CreateOfferRequest, walletAddr string, sellerUserID string) (*models.Offer, error) {
 	amountInt := req.Amount
 
 	if s.userWalletRepo != nil {

--- a/dong-service/services/order_service.go
+++ b/dong-service/services/order_service.go
@@ -28,7 +28,7 @@ func NewOrderService(repo *repository.OrderRepository, offerRepo *repository.Off
 }
 
 type IOrderService interface {
-	CreateOrder(ctx context.Context, offerID int64, req *models.CreateOrderRequest, walletAddress string, buyerUserID int64) (*models.Order, *models.Offer, error)
+	CreateOrder(ctx context.Context, offerID int64, req *models.CreateOrderRequest, walletAddress string, buyerUserID string) (*models.Order, *models.Offer, error)
 	ListOrdersByOffer(ctx context.Context, offerID int64, pagination map[string]any) ([]models.Order, error)
 	GetOrderByID(ctx context.Context, id int64) (*models.Order, error)
 	ConfirmOrderAsBuyer(ctx context.Context, orderID int64, o *models.Order) error
@@ -36,7 +36,7 @@ type IOrderService interface {
 	GetOrdersByWalletAddress(ctx context.Context, walletAddress string, pagination map[string]any) ([]models.Order, int64, error)
 }
 
-func (s *OrderService) CreateOrder(ctx context.Context, offerID int64, req *models.CreateOrderRequest, walletAddress string, buyerUserID int64) (*models.Order, *models.Offer, error) {
+func (s *OrderService) CreateOrder(ctx context.Context, offerID int64, req *models.CreateOrderRequest, walletAddress string, buyerUserID string) (*models.Order, *models.Offer, error) {
 	db := database.GetDB()
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {

--- a/dong-service/utils/handler_helpers.go
+++ b/dong-service/utils/handler_helpers.go
@@ -110,3 +110,18 @@ func GetAddressFromContext(c *gin.Context) (string, bool) {
 
 	return addressStr, true
 }
+
+func GetUserIDStringFromContext(c *gin.Context) (string, error) {
+	user, ok := c.Get("user")
+	if !ok {
+		return "", jwt.ErrTokenInvalidClaims
+	}
+
+	userID, ok := user.(jwt.MapClaims)["user_id"].(string)
+	if !ok {
+		return "", jwt.ErrTokenInvalidClaims
+	}
+
+	fmt.Println("userID", userID)
+	return userID, nil
+}


### PR DESCRIPTION
Update này chủ yếu add thêm logic getUserIDStringFromContext() trong utils 
Các logic liên quan Offer, Order => Chuyển hết int64 sang string ( handler, service, repo )
DB migration bảng 18 thay đổi BIGINT thành TEXT ( userid mezon độ dài mặc dù 19 nhưng maybe thay đổi...nền tảng khác chẳng hạn )
#536 