### PR TITLE
 remove redundant field when get zk proof and auth_token không l…

### DIFF
--- a/frontend/constant/storage-keys.constant.ts
+++ b/frontend/constant/storage-keys.constant.ts
@@ -2,7 +2,6 @@ const STORAGE_KEYS = {
   THEME: 'theme',
   LANGUAGE: 'mezon_language',
   SEARCH_HISTORY: 'mezon_search_history',
-  AUTH_TOKEN: 'auth_token',
   TOKEN: 'token',
   USER_INFO: 'user_info',
   KEY_PAIR: 'key_pair',

--- a/frontend/modules/auth/utils.ts
+++ b/frontend/modules/auth/utils.ts
@@ -17,7 +17,6 @@ export const handleTokenStorage = (userInfo: LoginResponse) => {
     refresh_token: userInfo.refresh_token,
   };
   localStorage.setItem(STORAGE_KEYS.TOKEN, JSON.stringify(token));
-  localStorage.setItem(STORAGE_KEYS.AUTH_TOKEN, userInfo.auth_token);
 };
 
 export const generateAndStoreKeyPair = () => {
@@ -39,17 +38,13 @@ export const processAndStoreUser = (userInfo: LoginResponse['user'], senderAddre
 };
 
 export const fetchAndStoreZkProof = async (
-  userId: string,
   ephemeralPublicKey: string,
-  jwt: string,
-  address: string
+  jwt: string
 ) => {
   try {
     const zkProof = await zkClient.getZkProofs({
-      userId,
       ephemeralPublicKey,
       jwt,
-      address,
     });
     localStorage.setItem(STORAGE_KEYS.ZK_PROOF, JSON.stringify(zkProof));
     return zkProof;

--- a/frontend/providers/AppProvider.tsx
+++ b/frontend/providers/AppProvider.tsx
@@ -99,10 +99,8 @@ export function AppProvider({ children }: AppProviderProps) {
         const userObject = processAndStoreUser(userInfo.user, senderAddress);
         setUser(userObject);
         const fetchedZk = await fetchAndStoreZkProof(
-          userInfo.user.user_id || userInfo.user.sub,
           keypair.publicKey,
           userInfo.auth_token,
-          senderAddress
         );
         if (fetchedZk) {
           setZkProof(fetchedZk);

--- a/frontend/utils/clear-storage.utils.ts
+++ b/frontend/utils/clear-storage.utils.ts
@@ -1,7 +1,6 @@
 import { STORAGE_KEYS } from '@/constant';
 export const AUTH_STORAGE_KEYS: readonly string[] = [
   STORAGE_KEYS.TOKEN,
-  STORAGE_KEYS.AUTH_TOKEN,
   STORAGE_KEYS.USER_INFO,
   STORAGE_KEYS.KEY_PAIR,
   STORAGE_KEYS.ZK_PROOF,


### PR DESCRIPTION
https://github.com/mezonai/mmn/issues/446
Xóa các input thừa lúc get proof ( userid và address )
Không lưu auth_token (id_token ) lúc login xong nữa.