### PR TITLE
ex533: Add validation for symbol and bankInfo in create offer API

### DIFF
--- a/dong-service/constants/status.go
+++ b/dong-service/constants/status.go
@@ -128,7 +128,10 @@ func IsValidStatus(status int16) bool {
 		status == CampaignStatusClosed
 }
 
-// Max price_rate offer
+// Offer related constants
 const (
-	MaxPriceRateOffer float64 = 1000000.0
+	MaxPriceRateOffer         float64 = 1000000.0
+	MaxLengthSymbol           int     = 64
+	MaxTotalBankInfoSize      int     = 1024
+	MaxIndividualBankInfoSize int     = 128
 )

--- a/dong-service/handlers/offer_handlers.go
+++ b/dong-service/handlers/offer_handlers.go
@@ -7,6 +7,7 @@ import (
 	"dong-service/models"
 	"dong-service/services"
 	"dong-service/utils"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"regexp"
@@ -86,6 +87,18 @@ func (h *OfferHandler) CreateOffer(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, models.ErrorResponse(http.StatusBadRequest, "Invalid request: price rate must be less than to 1,000,000"))
 			return
 		}
+	}
+
+	if len(req.Symbol) > constants.MaxLengthSymbol {
+		logger.Error().Msg("invalid create offer request: symbol length exceeds limit")
+		c.JSON(http.StatusBadRequest, models.ErrorResponse(http.StatusBadRequest, "Invalid request: symbol length exceeds limit"))
+		return
+	}
+
+	if err := validateBankInfo(req.BankInfo); err != nil {
+		logger.Error().Msg("invalid create offer request: " + err.Error())
+		c.JSON(http.StatusBadRequest, models.ErrorResponse(http.StatusBadRequest, "Invalid request: "+err.Error()))
+		return
 	}
 
 	userID, err := utils.GetUserIDStringFromContext(c)
@@ -360,7 +373,7 @@ func (h *OfferHandler) CancelOffer(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, models.ErrorResponse(http.StatusInternalServerError, constants.ErrFailedToGetOffer+": "+err.Error()))
 		return
 	}
-	
+
 	if offer == nil {
 		c.JSON(http.StatusNotFound, models.ErrorResponse(http.StatusNotFound, constants.ErrOfferNotFound))
 		return
@@ -379,4 +392,33 @@ func (h *OfferHandler) CancelOffer(c *gin.Context) {
 		"success": true,
 		"message": constants.MsgOfferCancelled,
 	})
+}
+
+func validateBankInfo(bankInfo map[string]interface{}) error {
+	if bankInfo == nil {
+		return nil
+	}
+
+	var totalSize int
+	for key, value := range bankInfo {
+		totalSize += len(key)
+
+		valueBytes, err := json.Marshal(value)
+		if err != nil {
+			return errors.New("invalid bank info value format")
+		}
+		valueSize := len(valueBytes)
+
+		if valueSize > constants.MaxIndividualBankInfoSize {
+			return errors.New("bank info value must not exceed 128 bytes")
+		}
+
+		totalSize += valueSize
+	}
+
+	if totalSize > constants.MaxTotalBankInfoSize {
+		return errors.New("bank info total size must not exceed 1024 bytes")
+	}
+
+	return nil
 }


### PR DESCRIPTION
# Ticket
#533 

# General
- [ ] No unnecessary files, debug logs, or commented code included.
- [ ] PR has at least 1 peer approval before senior review.
- [ ] I fully understand the code I submitted.
- [ ] No hardcoded configuration or secrets.
- [ ] **Environment Variables** changes? (Leave unchecked if N/A)

# Design & Solution Clarity
- 

# Testing
- create offer với `symbol` quá 64 kí tự
<img width="1503" height="765" alt="image" src="https://github.com/user-attachments/assets/9d0995e4-fd79-4138-a7c7-af565c22583e" />

- create offer với 1 trường giá trị trong `bank_info` vượt quá 128 byte
<img width="1507" height="813" alt="image" src="https://github.com/user-attachments/assets/74cafec0-09e5-4b5d-a8ee-07940f8fdf8d" />

- create offer với `bank_info` vượt quá 1024 byte
<img width="1536" height="1018" alt="image" src="https://github.com/user-attachments/assets/ee89157d-2a50-485f-b1e8-6153eb7e0c3a" />

# Peer Review Checklist
- [x] I understand the overall solution and flow.
- [x] The code follows the provided design diagram.
- [x] No obvious logic or security issues found.
- [ ] Tests are sufficient for the scope of this change.